### PR TITLE
Sublist can go backward, and loop back on itself

### DIFF
--- a/src/main/kotlin/com/ginsberg/cirkle/CircularList.kt
+++ b/src/main/kotlin/com/ginsberg/cirkle/CircularList.kt
@@ -25,6 +25,9 @@
 
 package com.ginsberg.cirkle
 
+import kotlin.math.absoluteValue
+import kotlin.math.sign
+
 /**
  * Implementation of a Circularly-addressable [kotlin.collections.List], allowing negative
  * indexes and positive indexes that are larger than the size of the List.
@@ -64,12 +67,13 @@ class CircularList<out T>(private val list: List<T>) : List<T> by list {
      * @sample samples.Cirkle.CircularList.subList
      */
     override fun subList(fromIndex: Int, toIndex: Int): List<T> {
-        val fromIndexSafe = fromIndex.safely()
-        val toIndexSafe = toIndex.safely()
-        if(toIndexSafe < fromIndexSafe) {
-            return list.subList(fromIndexSafe, list.size) + list.subList(0, toIndexSafe)
+        return if(fromIndex <= toIndex) {
+            fromIndex until toIndex
+        } else {
+            fromIndex downTo toIndex + 1
+        }.map {
+            list[it.safely()]
         }
-        return list.subList(fromIndexSafe, toIndexSafe)
     }
 
     /**

--- a/src/main/kotlin/com/ginsberg/cirkle/CircularList.kt
+++ b/src/main/kotlin/com/ginsberg/cirkle/CircularList.kt
@@ -63,8 +63,14 @@ class CircularList<out T>(private val list: List<T>) : List<T> by list {
      *
      * @sample samples.Cirkle.CircularList.subList
      */
-    override fun subList(fromIndex: Int, toIndex: Int): List<T> =
-        list.subList(fromIndex.safely(), toIndex.safely())
+    override fun subList(fromIndex: Int, toIndex: Int): List<T> {
+        val fromIndexSafe = fromIndex.safely()
+        val toIndexSafe = toIndex.safely()
+        if(toIndexSafe < fromIndexSafe) {
+            return list.subList(fromIndexSafe, list.size) + list.subList(0, toIndexSafe)
+        }
+        return list.subList(fromIndexSafe, toIndexSafe)
+    }
 
     /**
      * Returns a String representation of the object.

--- a/src/main/kotlin/com/ginsberg/cirkle/CircularList.kt
+++ b/src/main/kotlin/com/ginsberg/cirkle/CircularList.kt
@@ -25,9 +25,6 @@
 
 package com.ginsberg.cirkle
 
-import kotlin.math.absoluteValue
-import kotlin.math.sign
-
 /**
  * Implementation of a Circularly-addressable [kotlin.collections.List], allowing negative
  * indexes and positive indexes that are larger than the size of the List.

--- a/src/main/kotlin/com/ginsberg/cirkle/MutableCircularList.kt
+++ b/src/main/kotlin/com/ginsberg/cirkle/MutableCircularList.kt
@@ -113,12 +113,18 @@ class MutableCircularList<T>(private val list: MutableList<T>): MutableList<T> b
      * @sample samples.Cirkle.MutableCircularList.subList
      */
     override fun subList(fromIndex: Int, toIndex: Int): MutableList<T> {
-        val fromIndexSafe = fromIndex.safely()
-        val toIndexSafe = toIndex.safely()
-        if(toIndexSafe < fromIndexSafe) {
-            return (list.subList(fromIndexSafe, list.size) + list.subList(0, toIndexSafe)).toMutableList()
-        }
-        return list.subList(fromIndexSafe, toIndexSafe)
+        println("fromIndex: $fromIndex toIndex: $toIndex")
+        return if(fromIndex <= toIndex) {
+            println("First if")
+            fromIndex until toIndex
+        } else {
+            println("Second if")
+            fromIndex downTo toIndex + 1
+        }.map {
+            println("mapping it $it safely ${it.safely()}")
+            list[it.safely()]
+        }.toMutableList()
+
     }
 
     /**

--- a/src/main/kotlin/com/ginsberg/cirkle/MutableCircularList.kt
+++ b/src/main/kotlin/com/ginsberg/cirkle/MutableCircularList.kt
@@ -112,8 +112,14 @@ class MutableCircularList<T>(private val list: MutableList<T>): MutableList<T> b
      *
      * @sample samples.Cirkle.MutableCircularList.subList
      */
-    override fun subList(fromIndex: Int, toIndex: Int): MutableList<T> =
-        list.subList(fromIndex.safely(), toIndex.safely())
+    override fun subList(fromIndex: Int, toIndex: Int): MutableList<T> {
+        val fromIndexSafe = fromIndex.safely()
+        val toIndexSafe = toIndex.safely()
+        if(toIndexSafe < fromIndexSafe) {
+            return (list.subList(fromIndexSafe, list.size) + list.subList(0, toIndexSafe)).toMutableList()
+        }
+        return list.subList(fromIndexSafe, toIndexSafe)
+    }
 
     /**
      * Returns a String representation of the object.

--- a/src/main/kotlin/com/ginsberg/cirkle/MutableCircularList.kt
+++ b/src/main/kotlin/com/ginsberg/cirkle/MutableCircularList.kt
@@ -113,15 +113,11 @@ class MutableCircularList<T>(private val list: MutableList<T>): MutableList<T> b
      * @sample samples.Cirkle.MutableCircularList.subList
      */
     override fun subList(fromIndex: Int, toIndex: Int): MutableList<T> {
-        println("fromIndex: $fromIndex toIndex: $toIndex")
         return if(fromIndex <= toIndex) {
-            println("First if")
             fromIndex until toIndex
         } else {
-            println("Second if")
             fromIndex downTo toIndex + 1
         }.map {
-            println("mapping it $it safely ${it.safely()}")
             list[it.safely()]
         }.toMutableList()
 

--- a/src/main/kotlin/com/ginsberg/cirkle/MutableCircularList.kt
+++ b/src/main/kotlin/com/ginsberg/cirkle/MutableCircularList.kt
@@ -120,7 +120,6 @@ class MutableCircularList<T>(private val list: MutableList<T>): MutableList<T> b
         }.map {
             list[it.safely()]
         }.toMutableList()
-
     }
 
     /**

--- a/src/test/kotlin/com/ginsberg/cirkle/CircularListTest.kt
+++ b/src/test/kotlin/com/ginsberg/cirkle/CircularListTest.kt
@@ -65,7 +65,12 @@ class CircularListTest {
 
     @Test
     fun `subList with positive index wraps around`() {
-        assertThat(testList.subList(3, -1)).containsExactly(1, 2)
+        assertThat(testList.subList(3, -1)).containsExactly(1, 3, 2, 1)
+    }
+
+    @Test
+    fun `subList can lead to longer list than original`() {
+        assertThat(testList.subList(0, 4)).containsExactly(1, 2, 3, 1)
     }
 
     @Test
@@ -80,7 +85,7 @@ class CircularListTest {
 
     @Test
     fun `subList works with a combination of positive and negative indexes`() {
-        assertThat(testList.subList(0, -1)).containsExactly(1, 2)
+        assertThat(testList.subList(0, -1)).containsExactly(1)
     }
 
     @Test

--- a/src/test/kotlin/com/ginsberg/cirkle/CircularListTest.kt
+++ b/src/test/kotlin/com/ginsberg/cirkle/CircularListTest.kt
@@ -84,7 +84,13 @@ class CircularListTest {
     }
 
     @Test
+    fun `subList works when needing to go around back`() {
+        assertThat(testList.subList(2, 4)).containsExactly(3, 1)
+    }
+
+    @Test
     fun `toString delegates to list implementation`() {
         assertThat(testList.toString()).isEqualTo("[1, 2, 3]")
     }
+
 }

--- a/src/test/kotlin/com/ginsberg/cirkle/MutableCircularListTest.kt
+++ b/src/test/kotlin/com/ginsberg/cirkle/MutableCircularListTest.kt
@@ -115,7 +115,12 @@ class MutableCircularListTest {
 
     @Test
     fun `subList with positive index wraps around`() {
-        assertThat(testList.subList(3, -1)).containsExactly(1, 2)
+        assertThat(testList.subList(3, -1)).containsExactly(1,3,2,1)
+    }
+
+    @Test
+    fun `subList can lead to longer list than original`() {
+        assertThat(testList.subList(0, 4)).containsExactly(1, 2, 3, 1)
     }
 
     @Test
@@ -130,7 +135,7 @@ class MutableCircularListTest {
 
     @Test
     fun `subList works with a combination of positive and negative indexes`() {
-        assertThat(testList.subList(0, -1)).containsExactly(1, 2)
+        assertThat(testList.subList(0, -1)).containsExactly(1)
     }
 
     @Test

--- a/src/test/kotlin/com/ginsberg/cirkle/MutableCircularListTest.kt
+++ b/src/test/kotlin/com/ginsberg/cirkle/MutableCircularListTest.kt
@@ -115,7 +115,7 @@ class MutableCircularListTest {
 
     @Test
     fun `subList with positive index wraps around`() {
-        assertThat(testList.subList(3, -1)).containsExactly(1,3,2,1)
+        assertThat(testList.subList(3, -1)).containsExactly(1, 3, 2, 1)
     }
 
     @Test

--- a/src/test/kotlin/com/ginsberg/cirkle/MutableCircularListTest.kt
+++ b/src/test/kotlin/com/ginsberg/cirkle/MutableCircularListTest.kt
@@ -134,6 +134,11 @@ class MutableCircularListTest {
     }
 
     @Test
+    fun `subList works when needing to go around back`() {
+        assertThat(testList.subList(2, 4)).containsExactly(3, 1)
+    }
+
+    @Test
     fun `toString delegates to list implementation`() {
         assertThat(testList.toString()).isEqualTo("[1, 2, 3]")
     }


### PR DESCRIPTION
See also https://github.com/tginsberg/cirkle/issues/1

Can move backwards in the circular list and keep on going around as well. Not an efficient implementation though.